### PR TITLE
need call to jetty

### DIFF
--- a/cocoon/pom.xml
+++ b/cocoon/pom.xml
@@ -11,7 +11,14 @@
     <module>text</module>
     <module>viewer</module>
   </modules>
-
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.mortbay.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
   <dependencyManagement>
     <dependencies>
       <dependency>


### PR DESCRIPTION
jetty is not installed by default on all version of mvn. This change in the pom.xml let user don't have to think about the installation.
