### PR TITLE
have a README.md which explain correctly where needs to run jetty

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,6 @@ The following commands will build the web application and run it in Jetty:
     mvn validate
     mvn install
     cd viewer
-    mvn validate
-    mvn install
     mvn jetty:run
 
 The application will be available at `http://localhost:8888/text/`. You can


### PR DESCRIPTION
The previous readme.md said to run jetty on the `cocoon` folder, in place of `cocoon/viewer`. That was the last problematic problem with @Athromas (#12). To be confirmed of course, on windows.
